### PR TITLE
state param module reverted as previous module handled in platform

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -27,16 +27,13 @@ Copyright end */
         var viewParams = {
           indicator: row.entity.indicator
         };
-        var stateParams = $state.params;
-        stateParams.module = $scope.module;
         var params = {
           module:  $scope.module,
           id: row.entity.indicator,
           viewParams: JSON.stringify(viewParams),
           previousState: $state.current.name,
-          previousParams: JSON.stringify(stateParams)
+          previousParams: JSON.stringify($state.params)
         };
-        // $scope.$broadcast('csGrid:goTo', state, params, event);
         var leavingViewPanel = state.indexOf('viewPanel') === -1 && $state.current.name.indexOf('viewPanel') !== -1;
         if (event.ctrlKey || event.metaKey || leavingViewPanel) {
           var url = $state.href(state, params);


### PR DESCRIPTION
state param module reverted as previous module handled in platform

On opening and closing view panel, the module was not getting fetched correctly. 

https://gitlab-van.corp.fortinet.com/fortisoar/platform/exo-ui/-/merge_requests/622?view=parallel
