### PR TITLE
navigation restricted if IOC is invalid

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -23,13 +23,16 @@ Copyright end */
       }
 
       function onView(row, col, event) {
+        if(!row.entity.indicator.valid){ //to return and stop opening of view panel if IOC is invalid
+          return;
+        }
         var state = appModulesService.getState($scope.module);
         var viewParams = {
-          indicator: row.entity.indicator
+          indicator: row.entity.indicator.id
         };
         var params = {
           module:  $scope.module,
-          id: row.entity.indicator,
+          id: row.entity.indicator.id,
           viewParams: JSON.stringify(viewParams),
           previousState: $state.current.name,
           previousParams: JSON.stringify($state.params)


### PR DESCRIPTION
Restricted opening of view panel from grid if IOC is invalid
- [ ] verified for navigation of single IOC /single invalid ioc
- [ ]  verified for navigation of bulk IOC
- [ ]  verified for navigation of invalid IOC in set of bulk IOC's

<img width="1680" alt="Screenshot 2025-01-10 at 5 11 56 PM" src="https://github.com/user-attachments/assets/8bfd2b18-b3dc-4c43-b4bd-4df48ed1beb3" />



PR dependency - 
https://gitlab-van.corp.fortinet.com/fortisoar/widgets/widget-fortiguard-ioc-search/-/merge_requests/24
